### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/templates/widgets/lockout.twig
+++ b/src/templates/widgets/lockout.twig
@@ -15,7 +15,7 @@
 
 	<div class="lockout-icon-container {% if localSettings.enabled %}enabled{% else %}disabled{% endif %}">
 
-		{{ svg(view.getAssetManager().getPublishedPath('@jalendport/lockout/assetbundles/lockoutwidget/dist', true) ~ '/img/LockoutWidget-icon.svg', class='lockout-icon') }}
+		{{ svg(view.getAssetManager().getPublishedPath('@jalendport/lockout/assetbundles/lockoutwidget/dist', true) ~ '/img/LockoutWidget-icon.svg')|attr({class: 'lockout-icon'}) }}
 
 	</div>
 


### PR DESCRIPTION
> The class argument of the svg() Twig function has been deprecated. The |attr filter should be used instead.

I adapted the code from the craft docs at https://craftcms.com/docs/3.x/dev/functions.html#svg