### PR TITLE
Craft 5 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _Temporarily lock certain users out of the control panel._
 
 ### Requirements
 
-This plugin requires Craft CMS 4.0.0 or later.
+This plugin requires Craft CMS 5.0.0 or later.
 
 ### Plugin Store
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jalendport/craft-lockout",
     "description": "Temporarily lock certain users out of the control panel.",
     "type": "craft-plugin",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0"
+        "craftcms/cms": "^5.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bumps the required Craft CMS Version to support Craft CMS 5. Very simple change, I haven't tested it in all its details, but worked for my case. @jalendport — do you have any objections, or is there something more to consider?